### PR TITLE
Bug fix for availability count mismatch

### DIFF
--- a/Source/Microsoft.Teams.Apps.DLLookup/Repositories/PresenceDataRepository.cs
+++ b/Source/Microsoft.Teams.Apps.DLLookup/Repositories/PresenceDataRepository.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Teams.Apps.DLLookup.Repositories
                         for (int i = 0; i < peoplePresenceResults.Count; i++)
                         {
                             this.memoryCache.Set(peoplePresenceResults[i].Id, peoplePresenceResults[i], options);
-                            if (this.onlinePresenceOptions.Contains(peoplePresenceResults[i].Availability.ToUpper()))
+                            if (this.onlinePresenceOptions.Contains(peoplePresenceResults[i].Availability))
                             {
                                 onlineMembersCount++;
                             }


### PR DESCRIPTION
People presence(status) is coming in the exactly same case we have stored in the onlinePresenceOptions list i.e Busy, DoNotDistrub, Available but when we are making it upper case, the contains function was never returning true as it is case sensitive. So, the count was not increasing. 